### PR TITLE
Add defmodule to the docs to fix linking for #lang whalesong

### DIFF
--- a/whalesong/scribblings/manual.scrbl
+++ b/whalesong/scribblings/manual.scrbl
@@ -76,11 +76,11 @@ document lives in @url{http://hashcollision.org/whalesong}.}}
        @centered{@smaller{Current commit head is @tt{@git-head}.}})
      "")
 
-
-
 @;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 @section{Introduction}
 @;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@defmodule[whalesong #:lang]
 
 Whalesong is a compiler from Racket to JavaScript; it takes Racket
 programs and translates them so that they can run stand-alone on a


### PR DESCRIPTION
Currently, `#lang whalesong` lines in the documentation display as unlinked identifiers with the ugly red underline. This adds a `defmodule` declaration to fix that.