### PR TITLE
FIX: invalid number of arguments passed to SceneImage #10

### DIFF
--- a/whalesong/image/private/js-impl.js
+++ b/whalesong/image/private/js-impl.js
@@ -687,8 +687,9 @@ EXPORTS['empty-scene'] =
 	function(MACHINE) {
 	    var width = checkNonNegativeReal(MACHINE, 'empty-scene', 0);
 	    var height = checkNonNegativeReal(MACHINE, 'empty-scene', 1);
-      var color = (MACHINE.a===3)? checkColor(MACHINE, 'empty-scene', 2) : null;
-	    return makeSceneImage(jsnums.toFixnum(width),
+            var color = (MACHINE.a===3)? checkColor(MACHINE, 'empty-scene', 2) : null;
+
+            return new SceneImage(jsnums.toFixnum(width),
                                   jsnums.toFixnum(height),
                                   color,
                                   [],

--- a/whalesong/image/private/kernel.js
+++ b/whalesong/image/private/kernel.js
@@ -303,6 +303,7 @@ SceneImage.prototype = heir(BaseImage.prototype);
 SceneImage.prototype.add = function(anImage, x, y) {
   return new SceneImage(this.width,
                         this.height,
+                        null,
                         this.children.concat([[anImage,
                                                x - anImage.getWidth()/2,
                                                y - anImage.getHeight()/2]]),
@@ -1311,7 +1312,7 @@ var colorListToImage = function(listOfColors,
 
 
 var makeSceneImage = function(width, height, children, withBorder) {
-    return new SceneImage(width, height, children, withBorder);
+    return new SceneImage(width, height, null, children, withBorder);
 };
 var makeCircleImage = function(radius, style, color) {
     return new EllipseImage(2*radius, 2*radius, style, color);


### PR DESCRIPTION
makeSceneImage() as well as SceneImage.add function in kernel.js was using SceneImage constructor with wrong number of arguments, making various image functions fail.