### PR TITLE
Implement place-images* functions in image library

### DIFF
--- a/whalesong/image/main.rkt
+++ b/whalesong/image/main.rkt
@@ -1,7 +1,9 @@
 #lang s-exp "../lang/base.rkt"
 
 (require "private/main.rkt"
-         "private/color.rkt")
+         "private/color.rkt"
+         "private/image.rkt")
 
 (provide (all-from-out "private/main.rkt")
-         (all-from-out "private/color.rkt"))
+         (all-from-out "private/color.rkt")
+         (all-from-out "private/image.rkt"))

--- a/whalesong/image/private/image.rkt
+++ b/whalesong/image/private/image.rkt
@@ -1,0 +1,22 @@
+#lang s-exp "../../lang/base.rkt"
+
+;; Image functions that be implemented using racket based on primitives
+
+(require "main.rkt"
+         "../../lang/for.rkt"
+         "../../lang/posn.rkt")
+
+(provide place-images
+         place-images/align)
+
+; place-images : (listof image?) (listof posn?) image? -> image?
+(define (place-images images posns scene)
+  (for/fold ([acc scene])
+            ([img images] [posn posns])
+            (place-image img (posn-x posn) (posn-y posn) acc)))
+
+; place-images : (listof image?) (listof posn?) x-place? y-place? image? -> image?
+(define (place-images/align images posns x-place y-place scene)
+  (for/fold ([acc scene])
+            ([img images] [posn posns])
+            (place-image/align img (posn-x posn) (posn-y posn) x-place y-place acc)))


### PR DESCRIPTION
place-images* functions could be implemented using the primitive place-image function implemented in JS. Added image.rkt for implementing these and any other functions that could be implemented in racket.