### PR TITLE
Revert "trying to get rid of the current success handler." FIXES #34

### DIFF
--- a/whalesong/js-assembler/assemble.rkt
+++ b/whalesong/js-assembler/assemble.rkt
@@ -65,6 +65,7 @@
     (display (assemble-current-interned-constant-closure-table) op)
     
     (display "M.params.currentErrorHandler = fail;\n" op)
+    (display "M.params.currentSuccessHandler = success;\n" op)
     (display  #<<EOF
 for (param in params) {
     if (Object.hasOwnProperty.call(params, param)) {
@@ -79,7 +80,6 @@ EOF
                     (assemble-label (make-Label (BasicBlock-name (first basic-blocks)))))]
           [else
            ;; Otherwise, we want to run under a trampolining context.
-           (display "M.c.push(new RT.CallFrame(function(M){ setTimeout(success, 0); },M.p));\n" op)
            (fprintf op "M.trampoline(~a, ~a); })"
                     (assemble-label (make-Label (BasicBlock-name (first basic-blocks))))
                     (cond [(eq? trampoline-option 'with-preemption)

--- a/whalesong/js-assembler/runtime-src/runtime.js
+++ b/whalesong/js-assembler/runtime-src/runtime.js
@@ -297,6 +297,7 @@
 	    'currentOutputPort': new StandardOutputPort(),
 	    'currentErrorPort': new StandardErrorPort(),
             'currentInputPort': new StandardInputPort(),
+	    'currentSuccessHandler': function(MACHINE) {},
 	    'currentErrorHandler': function(MACHINE, exn) {
                 MACHINE.params.currentErrorDisplayer(
                     MACHINE,
@@ -752,6 +753,7 @@
 
         that.running = false;
         that.breakScheduled = false;
+        that.params.currentSuccessHandler(that);
         release();
         return;
 

--- a/whalesong/tests/test-assemble.rkt
+++ b/whalesong/tests/test-assemble.rkt
@@ -69,7 +69,7 @@
                             (display "var M = new plt.runtime.Machine();\n" op)                           
                             (display "(function() { " op)
                             (display "var myInvoke = " op)
-                            (assemble/write-invoke a-statement op)
+                            (assemble/write-invoke a-statement op 'with-preemption)
                             (display ";" op)
                             (fprintf op 
                                      "return function(succ, fail, params) {


### PR DESCRIPTION
Reverted patch, added success handler to end of call stack, which is not
getting called. We already have separate handlers for error, so we might
as well have one for success explicitely.

This reverts commit 0428a021bd2e94953c3b3086d2c5fa1cbd5dbb81.

Conflicts:
	whalesong/js-assembler/assemble.rkt
	whalesong/js-assembler/runtime-src/runtime.js