### PR TITLE
Inline definition of `in-syntax`.

### DIFF
--- a/whalesong/lang/private/match/define-forms.rkt
+++ b/whalesong/lang/private/match/define-forms.rkt
@@ -3,7 +3,7 @@
 (require (for-syntax racket/base
                      racket/syntax
                      (only-in racket/list append* remove-duplicates)
-                     unstable/sequence
+                     syntax/stx
                      syntax/parse
                      syntax/parse/experimental/template
                      racket/lazy-require))
@@ -145,9 +145,9 @@
          [(_ ((~and cl [pat exp]) ...) body1 body ...)
           (quasisyntax/loc stx
 			   (let ()
-                            #,@(for/list ([c (in-syntax #'(cl ...))]
-                                          [p (in-syntax #'(pat ...))]
-                                          [e (in-syntax #'(exp ...))])
+                            #,@(for/list ([c (in-list (stx->list #'(cl ...)))]
+                                          [p (in-list (stx->list #'(pat ...)))]
+                                          [e (in-list (stx->list #'(exp ...)))])
                                  (quasisyntax/loc c (match-define #,p #,e)))
                             body1 body ...))]))
 


### PR DESCRIPTION
That function is moving from `unstable/sequence` to `racket/sequence`.

Inlining it preserves backwards compatibility while removing the dependency on unstable.

Other options would be:
* Add an explicit dependency on `unstable-lib`, and keep using `in-syntax` from `unstable/sequence`. This is backwards compatible with 6.2.1 and before.
* Switch to using `in-syntax` from `racket/sequence`. This is not compatible with 6.2.1 and before, which can be remedied with a package version exception.