### PR TITLE
Set the reporting port to the error port by default

### DIFF
--- a/whalesong/parameters.rkt
+++ b/whalesong/parameters.rkt
@@ -88,7 +88,7 @@
 
 
 (: current-report-port (Parameterof Output-Port))
-(define current-report-port (make-parameter (current-output-port)))
+(define current-report-port (make-parameter (current-error-port)))
 
 
 (: current-timing-port (Parameterof Output-Port))

--- a/whalesong/whalesong-cmd.rkt
+++ b/whalesong/whalesong-cmd.rkt
@@ -200,7 +200,7 @@
                       (current-verbose? #t)]
                      [("--debug-show-timings")
                       ("Display debug messages about compilation time.")
-                      (current-timing-port (current-output-port))]
+                      (current-timing-port (current-error-port))]
                      [("--enable-profiling")
                       ("Enable profiling to standard output")
                       (with-profiling? #t)]


### PR DESCRIPTION
This is important for the get-javascript command, which outputs the result to stdout. In order for this to be useful, it can be redirected to a file, but if reporting information also goes to stdout, then it ends up in the resulting JavaScript. Switching these messages to stderr prevents that problem.
